### PR TITLE
set appVersion to the spinnaker's version it's going to deploy

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
 version: 2.2.3
-appVersion: 1.16.2
+appVersion: 1.22.2
 home: http://spinnaker.io/
 sources:
 - https://github.com/spinnaker

--- a/templates/configmap/bom.yaml
+++ b/templates/configmap/bom.yaml
@@ -6,6 +6,6 @@ metadata:
   labels:
 {{ include "spinnaker.standard-labels" . | indent 4 }}
 data:
-  {{ .Values.halyard.spinnakerVersion }}.yml:
+  {{ .Values.halyard.spinnakerVersion | default .Chart.AppVersion }}.yml:
   {{ .Values.halyard.bom | toYaml | indent 4 }}
 {{- end }}

--- a/templates/configmap/halyard-config.yaml
+++ b/templates/configmap/halyard-config.yaml
@@ -35,9 +35,9 @@ data:
   config.sh: |
     # Spinnaker version
     {{ if .Values.halyard.bom }}
-    $HAL_COMMAND config version edit --version local:{{ .Values.halyard.spinnakerVersion }}
+    $HAL_COMMAND config version edit --version local:{{ .Values.halyard.spinnakerVersion | default .Chart.AppVersion }}
     {{ else }}
-    $HAL_COMMAND config version edit --version {{ .Values.halyard.spinnakerVersion }}
+    $HAL_COMMAND config version edit --version {{ .Values.halyard.spinnakerVersion | default .Chart.AppVersion }}
     {{ end }}
 
     # Storage

--- a/values.yaml
+++ b/values.yaml
@@ -1,5 +1,5 @@
 halyard:
-  spinnakerVersion: 1.22.2
+  #spinnakerVersion: 1.22.2
   image:
     repository: gcr.io/spinnaker-marketplace/halyard
     tag: 1.39.0


### PR DESCRIPTION
Hi guys,
I feel that the current appVersion is misleading since it looks like it is going to deploy 1.16 version which is a year old. This is quite noticable on the [artifacthub page for this chart](https://artifacthub.io/packages/helm/spinnaker/spinnaker)

When you create a helm chart using helm create you get the following description by default:

```
# This is the version number of the application being deployed. This version number should be
# incremented each time you make changes to the application. Versions are not expected to
# follow Semantic Versioning. They should reflect the version the application is using.
```
Thus I think this value should be updated at the same time as you update the halyard.spinnakerVersion on the file values.yaml

kind regards,