### PR TITLE
Reduce default minio storage to 10Gi

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -285,7 +285,7 @@ minio:
 
   # Minio persistent storage settings
   persistence:
-    size: 30Gi
+    size: 10Gi
     # Uncomment below line if you don't want to enable persistent storage
     # for minio
     # enabled: false

--- a/values.yaml
+++ b/values.yaml
@@ -282,9 +282,13 @@ minio:
     enabled: true
     name: "spinnaker"
   nodeSelector: {}
-# Uncomment if you don't want to create a PVC for minio
-#  persistence:
-#    enabled: false
+
+  # Minio persistent storage settings
+  persistence:
+    size: 30Gi
+    # Uncomment below line if you don't want to enable persistent storage
+    # for minio
+    # enabled: false
 
 # Google Cloud Storage
 gcs:


### PR DESCRIPTION
By default minio chart creates a PVC for 500Gi which is too huge, changing this to 10Gi