### PR TITLE
Add support for v1 ingresses

### DIFF
--- a/templates/ingress/deck.yaml
+++ b/templates/ingress/deck.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.ingress.enabled }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else -}}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
 {{- if .Values.ingress.annotations }}
@@ -10,6 +14,9 @@ metadata:
   labels:
 {{ include "spinnaker.standard-labels" . | indent 4 }}
 spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   rules:
   - host: {{ .Values.ingress.host | quote }}
     http:
@@ -23,9 +30,18 @@ spec:
       {{- else}}{{/* Has no annotations */}}
       - path: /
       {{- end }}
-        backend:
-          serviceName: spin-deck
-          servicePort: 9000
+        {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+        pathType: ImplementationSpecific
+        {{- end }}
+        {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+        service:
+          name: spin-deck
+          port:
+            number: 9000
+        {{- else }}
+        serviceName: spin-deck
+        servicePort: 9000
+        {{- end }}
 {{- if .Values.ingress.tls }}
   tls:
 {{ toYaml .Values.ingress.tls | indent 4 }}

--- a/templates/ingress/deck.yaml
+++ b/templates/ingress/deck.yaml
@@ -33,15 +33,16 @@ spec:
         {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
         pathType: ImplementationSpecific
         {{- end }}
-        {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
-        service:
-          name: spin-deck
-          port:
-            number: 9000
-        {{- else }}
-        serviceName: spin-deck
-        servicePort: 9000
-        {{- end }}
+        backend:
+          {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+          service:
+            name: spin-deck
+            port:
+              number: 9000
+          {{- else }}
+          serviceName: spin-deck
+          servicePort: 9000
+          {{- end }}
 {{- if .Values.ingress.tls }}
   tls:
 {{ toYaml .Values.ingress.tls | indent 4 }}

--- a/templates/ingress/gate.yaml
+++ b/templates/ingress/gate.yaml
@@ -1,5 +1,9 @@
 {{- if .Values.ingressGate.enabled }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else -}}
 apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
 {{- if .Values.ingressGate.annotations }}
@@ -10,6 +14,9 @@ metadata:
   labels:
 {{ include "spinnaker.standard-labels" . | indent 4 }}
 spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   rules:
   - host: {{ .Values.ingressGate.host | quote }}
     http:
@@ -23,9 +30,19 @@ spec:
       {{- else}}{{/* Has no annotations */}}
       - path: /
       {{- end }}
+        {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+        pathType: ImplementationSpecific
+        {{- end }}
         backend:
+          {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+          service:
+            name: spin-gate
+            port:
+              number: 8084
+          {{- else }}
           serviceName: spin-gate
           servicePort: 8084
+          {{- end }}
 {{- if .Values.ingressGate.tls }}
   tls:
 {{ toYaml .Values.ingressGate.tls | indent 4 }}

--- a/values.yaml
+++ b/values.yaml
@@ -213,6 +213,7 @@ kubeConfig:
 # Change this if youd like to expose Spinnaker outside the cluster
 ingress:
   enabled: false
+  # className: 
   # host: spinnaker.example.org
   # annotations:
     # ingress.kubernetes.io/ssl-redirect: 'true'


### PR DESCRIPTION
Adding support for the V1 ingress spec

- API version changes to networking.k8s.io/v1
- support providing an `ingressClassName`
- support new structure for defining backends

See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/
