### PR TITLE
edit readme chart info

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Specify each parameter using the `--set key=value[,key=value]` argument to `helm
 Alternatively, a YAML file that specifies the values for the parameters can be provided while installing the chart. For example,
 
 ```bash
-$ helm install --name my-release -f values.yaml stable/spinnaker
+$ helm install --name my-release -f values.yaml spinnaker/spinnaker
 ```
 
 > **Tip**: You can use the default [values.yaml](values.yaml)
@@ -172,7 +172,7 @@ your configuration data persists any node failures, reboots or upgrades.
 For example:
 
 ```shell
-$ helm install -n cd stable/spinnaker
+$ helm install -n cd spinnaker/spinnaker
 $ kubectl exec -it cd-spinnaker-halyard-0 bash
 spinnaker@cd-spinnaker-halyard-0:/workdir$ hal version list
 ```


### PR DESCRIPTION
stable/spinnaker is deprecated    

```
ᐅ helm install my-release -f values.yaml stable/spinnaker       

WARNING: This chart is deprecated
Error: INSTALLATION FAILED: template: spinnaker/charts/minio/templates/deployment.yaml:210:20: executing "spinnaker/charts/minio/templates/deployment.yaml" at <(not .Values.gcsgateway.enabled) (not .Values.azuregateway.enabled) (not .Values.s3gateway.enabled) (not .Values.b2gateway.enabled)>: can't give argument to non-function not .Values.gcsgateway.enabled
```