### PR TITLE
Allow no-validate parameter for docker registry

### DIFF
--- a/charts/spinnaker/Chart.yaml
+++ b/charts/spinnaker/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: Open source, multi-cloud continuous delivery platform for releasing software changes with high velocity and confidence.
 name: spinnaker
-version: 2.2.10
+version: 2.2.11
 appVersion: 1.26.6
 home: http://spinnaker.io/
 sources:

--- a/charts/spinnaker/templates/configmap/halyard-config.yaml
+++ b/charts/spinnaker/templates/configmap/halyard-config.yaml
@@ -103,6 +103,7 @@ data:
       {{ if $registry.username -}} --username {{ $registry.username }} \
       {{ if $registry.passwordCommand -}} --password-command "{{ $registry.passwordCommand }}"{{ else -}} --password-file /opt/registry/passwords/{{ $registry.name }}{{- end }} \
       {{ if $registry.email -}} --email {{ $registry.email }}{{- end -}}{{- end }} \
+      {{ if $registry.noValidate -}} --no-validate {{- end }} \
       {{ if $registry.repositories -}} --repositories {{ range $index, $repository := $registry.repositories }}{{if $index}},{{end}}{{- $repository }}{{- end }}{{- end }}
 
     {{- end }}

--- a/charts/spinnaker/values.yaml
+++ b/charts/spinnaker/values.yaml
@@ -140,17 +140,20 @@ halyard:
 dockerRegistries:
 - name: dockerhub
   address: index.docker.io
+  noValidate: false
   repositories:
     - library/alpine
     - library/ubuntu
     - library/centos
     - library/nginx
 # - name: gcr
+#   noValidate: false
 #   address: https://gcr.io
 #   username: _json_key
 #   password: '<INSERT YOUR SERVICE ACCOUNT JSON HERE>'
 #   email: 1234@5678.com
 # - name: ecr
+#   noValidate: false
 #   address: <AWS-ACCOUNT-ID>.dkr.ecr.<REGION>.amazonaws.com
 #   username: AWS
 #   passwordCommand: aws --region <REGION> ecr get-authorization-token --output text --query 'authorizationData[].authorizationToken' | base64 -d | sed 's/^AWS://'


### PR DESCRIPTION
Solves https://github.com/OpsMx/spinnaker-helm/issues/22

From: https://github.com/spinnaker/halyard/blob/master/docs/commands.md#hal-config-provider-docker-registry

`--no-validate: (Default: false) Skip validation.`