### PR TITLE
Fix Redis wrong password

### DIFF
--- a/charts/spinnaker/values.yaml
+++ b/charts/spinnaker/values.yaml
@@ -264,7 +264,8 @@ redis:
     host: "<EXTERNAL-REDIS-HOST-NAME>"
     port: 6379
     # password: ""
-  password: password
+  auth:
+    password: password
   nodeSelector: {}
   cluster:
     enabled: false


### PR DESCRIPTION
Fix https://github.com/OpsMx/spinnaker-helm/issues/28

When installing Helm Chart for the first time with default values, got this error on `rosco`, `orca`, `clouddriver` and `gate` microservices :

> Caused by: redis.clients.jedis.exceptions.JedisDataException: WRONGPASS invalid username-password pair or user is disabled.